### PR TITLE
add event for new list items

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ Below are some examples of how to do this, click to expand.
     - platform: event
         event_type: google_keep_sync_new_item
         variables:
-        item_name: "{{ trigger.event.data.item_name }}"
-        item_id: "{{ trigger.event.data.item_id }}"
-        item_checked: "{{ trigger.event.data.item_checked }}"
-        list_name: "{{ trigger.event.data.list_name }}"
-        list_id: "{{ trigger.event.data.list_id }}"
+            item_name: "{{ trigger.event.data.item_name }}"
+            item_id: "{{ trigger.event.data.item_id }}"
+            item_checked: "{{ trigger.event.data.item_checked }}"
+            list_name: "{{ trigger.event.data.list_name }}"
+            list_id: "{{ trigger.event.data.list_id }}"
     condition:
     # Update this to the name of your shopping list in Home Assistant.
     - condition: template
@@ -162,7 +162,7 @@ Below are some examples of how to do this, click to expand.
         data:
         status: completed
         item: "{{item_name}}"
-    # The maximum number of updates you want to process each update. If you do a lot of chanes, increase this number.
+    # The maximum number of updates you want to process each update. If you make frequent changes, increase this number.
     mode: parallel
     max: 50
     ```
@@ -187,11 +187,11 @@ The same process works for Bring Shopping list or any other integrated list to H
     - platform: event
         event_type: google_keep_sync_new_item
         variables:
-        item_name: "{{ trigger.event.data.item_name }}"
-        item_id: "{{ trigger.event.data.item_id }}"
-        item_checked: "{{ trigger.event.data.item_checked }}"
-        list_name: "{{ trigger.event.data.list_name }}"
-        list_id: "{{ trigger.event.data.list_id }}"
+            item_name: "{{ trigger.event.data.item_name }}"
+            item_id: "{{ trigger.event.data.item_id }}"
+            item_checked: "{{ trigger.event.data.item_checked }}"
+            list_name: "{{ trigger.event.data.list_name }}"
+            list_id: "{{ trigger.event.data.list_id }}"
     condition:
     # Update this to the name of your shopping list in Home Assistant.
     - condition: template
@@ -217,7 +217,7 @@ The same process works for Bring Shopping list or any other integrated list to H
         data:
         status: completed
         item: "{{item_name}}"
-    # The maximum number of updates you want to process each update. If you do a lot of chanes, increase this number.
+    # The maximum number of updates you want to process each update. If you make frequent changes, increase this number.
     mode: parallel
     max: 50
     ```

--- a/README.md
+++ b/README.md
@@ -161,8 +161,9 @@ Below are some examples of how to do this, click to expand.
         data:
         status: completed
         item: "{{item_name}}"
-    ""
-    mode: single
+    # The maximum number of updates you want to process each update. If you do a lot of chanes, increase this number.
+    mode: parallel
+    max: 50
     ```
 
     </details>
@@ -215,8 +216,9 @@ The same process works for Bring Shopping list or any other integrated list to H
         data:
         status: completed
         item: "{{item_name}}"
-    mode: single
-
+    # The maximum number of updates you want to process each update. If you do a lot of chanes, increase this number.
+    mode: parallel
+    max: 50
     ```
 
     </details>

--- a/custom_components/google_keep_sync/__init__.py
+++ b/custom_components/google_keep_sync/__init__.py
@@ -3,24 +3,21 @@
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import GoogleKeepAPI
 from .const import DOMAIN
+from .coordinator import GoogleKeepSyncCoordinator
 
 PLATFORMS: list[Platform] = [Platform.TODO]
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(  # noqa: C901
-    hass: HomeAssistant, entry: ConfigEntry
-) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Google Keep Sync from a config entry."""
     # Create API instance
     api = GoogleKeepAPI(hass, entry.data["username"], entry.data["password"])
@@ -30,97 +27,18 @@ async def async_setup_entry(  # noqa: C901
         _LOGGER.error("Failed to authenticate Google Keep API")
         return False  # Exit early if authentication fails
 
-    async def _parse_gkeep_data_dict() -> dict[str, dict[str, dict[str, str]]]:
-        """Parse unchecked gkeep api data to a dictionary."""
-        todo_lists = {}
-
-        # for each list
-        for glist in coordinator.data or []:
-            # get all the unchecked items only
-            items = {
-                item.id: {"summary": item.text, "checked": item.checked}
-                for item in glist.items
-                if not item.checked
-            }
-            todo_lists[glist.id] = {"name": glist.title, "items": items}
-        return todo_lists
-
-    async def _check_gkeep_lists_changes(original_lists, updated_lists) -> None:
-        """Compare original_lists and updated_lists lists.
-
-        Report on any new TodoItem's that have been added to any
-        lists in updated_lists that are not in original_lists.
-        """
-        # for each list
-        for upldated_list_id, upldated_list in updated_lists.items():
-            if upldated_list_id not in original_lists:
-                _LOGGER.debug(
-                    "Found new list not in original: %s", upldated_list["name"]
-                )
-                continue
-
-            # for each todo item in the list
-            for upldated_list_item_id, upldated_list_item in upldated_list[
-                "items"
-            ].items():
-                # if todo is not in original list, then it is new
-                if (
-                    upldated_list_item_id
-                    not in original_lists[upldated_list_id]["items"]
-                ):
-                    list_prefix = entry.data.get("list_prefix", "")
-                    data = {
-                        "item_name": upldated_list_item["summary"],
-                        "item_id": upldated_list_item_id,
-                        "item_checked": upldated_list_item["checked"],
-                        "list_name": (f"{list_prefix} " if list_prefix else "")
-                        + upldated_list["name"],
-                        "list_id": upldated_list_id,
-                    }
-
-                    _LOGGER.debug("Found new TodoItem: %s", data)
-                    hass.bus.async_fire("google_keep_sync_new_item", data)
-
-    # Define the update method for the coordinator
-    async def async_update_data():
-        """Fetch data from API."""
-        try:
-            # save lists prior to syncing
-            original_lists = await _parse_gkeep_data_dict()
-            # Directly call the async_sync_data method
-            lists_to_sync = entry.data.get("lists_to_sync", [])
-            result = await api.async_sync_data(lists_to_sync)
-            # save lists after syncing
-            updated_lists = await _parse_gkeep_data_dict()
-            # compare both list for changes
-            await _check_gkeep_lists_changes(original_lists, updated_lists)
-
-            return result
-        except Exception as error:
-            raise UpdateFailed(f"Error communicating with API: {error}") from error
-
     # Create the coordinator
-    coordinator = DataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        name="Google Keep",
-        update_method=async_update_data,
-        update_interval=timedelta(minutes=15),
-    )
+    coordinator = GoogleKeepSyncCoordinator(hass, api)
 
     # Start the data update coordinator
-    await coordinator.async_refresh()
+    await coordinator.async_config_entry_first_refresh()
 
-    # Store the API and coordinator objects in hass.data
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
-        "api": api,
-        "coordinator": coordinator,
-    }
+    # Store the coordinator object in hass.data
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = coordinator
 
     # Forward the setup to the todo platform
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 

--- a/custom_components/google_keep_sync/__init__.py
+++ b/custom_components/google_keep_sync/__init__.py
@@ -18,7 +18,9 @@ PLATFORMS: list[Platform] = [Platform.TODO]
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  # noqa: C901
+async def async_setup_entry(  # noqa: C901
+    hass: HomeAssistant, entry: ConfigEntry
+) -> bool:
     """Set up Google Keep Sync from a config entry."""
     # Create API instance
     api = GoogleKeepAPI(hass, entry.data["username"], entry.data["password"])

--- a/custom_components/google_keep_sync/__init__.py
+++ b/custom_components/google_keep_sync/__init__.py
@@ -28,7 +28,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         return False  # Exit early if authentication fails
 
     # Create the coordinator
-    coordinator = GoogleKeepSyncCoordinator(hass, api)
+    coordinator = GoogleKeepSyncCoordinator(hass, api, entry)
 
     # Start the data update coordinator
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/google_keep_sync/__init__.py
+++ b/custom_components/google_keep_sync/__init__.py
@@ -18,7 +18,7 @@ PLATFORMS: list[Platform] = [Platform.TODO]
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  # noqa: C901
     """Set up Google Keep Sync from a config entry."""
     # Create API instance
     api = GoogleKeepAPI(hass, entry.data["username"], entry.data["password"])
@@ -28,13 +28,72 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.error("Failed to authenticate Google Keep API")
         return False  # Exit early if authentication fails
 
+    async def _parse_gkeep_data_dict() -> dict[str, dict[str, dict[str, str]]]:
+        """Parse unchecked gkeep api data to a dictionary."""
+        todo_lists = {}
+
+        # for each list
+        for glist in coordinator.data or []:
+            # get all the unchecked items only
+            items = {
+                item.id: {"summary": item.text, "checked": item.checked}
+                for item in glist.items
+                if not item.checked
+            }
+            todo_lists[glist.id] = {"name": glist.title, "items": items}
+        return todo_lists
+
+    async def _check_gkeep_lists_changes(original_lists, updated_lists) -> None:
+        """Compare original_lists and updated_lists lists.
+
+        Report on any new TodoItem's that have been added to any
+        lists in updated_lists that are not in original_lists.
+        """
+        # for each list
+        for upldated_list_id, upldated_list in updated_lists.items():
+            if upldated_list_id not in original_lists:
+                _LOGGER.debug(
+                    "Found new list not in original: %s", upldated_list["name"]
+                )
+                continue
+
+            # for each todo item in the list
+            for upldated_list_item_id, upldated_list_item in upldated_list[
+                "items"
+            ].items():
+                # if todo is not in original list, then it is new
+                if (
+                    upldated_list_item_id
+                    not in original_lists[upldated_list_id]["items"]
+                ):
+                    list_prefix = entry.data.get("list_prefix", "")
+                    data = {
+                        "item_name": upldated_list_item["summary"],
+                        "item_id": upldated_list_item_id,
+                        "item_checked": upldated_list_item["checked"],
+                        "list_name": (f"{list_prefix} " if list_prefix else "")
+                        + upldated_list["name"],
+                        "list_id": upldated_list_id,
+                    }
+
+                    _LOGGER.debug("Found new TodoItem: %s", data)
+                    hass.bus.async_fire("google_keep_sync_new_item", data)
+
     # Define the update method for the coordinator
     async def async_update_data():
         """Fetch data from API."""
         try:
+            # save lists prior to syncing
+            original_lists = await _parse_gkeep_data_dict()
             # Directly call the async_sync_data method
             lists_to_sync = entry.data.get("lists_to_sync", [])
-            return await api.async_sync_data(lists_to_sync)
+            result = await api.async_sync_data(lists_to_sync)
+            # save lists after syncing
+            updated_lists = await _parse_gkeep_data_dict()
+            # compare both list for changes
+            await _check_gkeep_lists_changes(original_lists, updated_lists)
+
+            return result
         except Exception as error:
             raise UpdateFailed(f"Error communicating with API: {error}") from error
 

--- a/custom_components/google_keep_sync/const.py
+++ b/custom_components/google_keep_sync/const.py
@@ -1,3 +1,4 @@
 """Constants for the Google Keep Sync integration."""
 
 DOMAIN = "google_keep_sync"
+EVENT_NEW_ITEM = "google_keep_sync_new_item"

--- a/custom_components/google_keep_sync/const.py
+++ b/custom_components/google_keep_sync/const.py
@@ -1,3 +1,6 @@
 """Constants for the Google Keep Sync integration."""
 
+from datetime import timedelta
+
 DOMAIN = "google_keep_sync"
+SCAN_INTERVAL = timedelta(minutes=15)

--- a/custom_components/google_keep_sync/const.py
+++ b/custom_components/google_keep_sync/const.py
@@ -1,4 +1,3 @@
 """Constants for the Google Keep Sync integration."""
 
 DOMAIN = "google_keep_sync"
-EVENT_NEW_ITEM = "google_keep_sync_new_item"

--- a/custom_components/google_keep_sync/coordinator.py
+++ b/custom_components/google_keep_sync/coordinator.py
@@ -2,23 +2,22 @@
 
 import logging
 from collections import namedtuple
-from collections.abc import Callable
 from datetime import timedelta
 
 from gkeepapi.node import List as GKeepList
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.const import EVENT_CALL_SERVICE, Platform
+from homeassistant.core import EventOrigin, HomeAssistant
+from homeassistant.helpers import entity_registry
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import GoogleKeepAPI
-from .const import DOMAIN, EVENT_NEW_ITEM
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 TodoItem = namedtuple("TodoItem", ["summary", "checked"])
 TodoList = namedtuple("TodoList", ["name", "items"])
-TodoItemData = namedtuple(
-    "TodoItemData", ["item_name", "item_id", "item_checked", "list_name", "list_id"]
-)
+TodoItemData = namedtuple("TodoItemData", ["item", "entity_id"])
 
 
 class GoogleKeepSyncCoordinator(DataUpdateCoordinator[list[GKeepList]]):
@@ -55,14 +54,11 @@ class GoogleKeepSyncCoordinator(DataUpdateCoordinator[list[GKeepList]]):
             # save lists after syncing
             updated_lists = await self._parse_gkeep_data_dict()
             # compare both list for changes, and fire event for changes
-            await self._handle_new_items_added(
+            new_items = await self._handle_new_items_added(
                 original_lists,
                 updated_lists,
-                self.config_entry.data.get("list_prefix", ""),
-                lambda item_data: self.hass.bus.async_fire(
-                    EVENT_NEW_ITEM, item_data._asdict()
-                ),
             )
+            await self._notify_new_items(new_items)
 
             return result
         except Exception as error:
@@ -87,9 +83,7 @@ class GoogleKeepSyncCoordinator(DataUpdateCoordinator[list[GKeepList]]):
         self,
         original_lists: dict[str, TodoList],
         updated_lists: dict[str, TodoList],
-        list_prefix: str,
-        on_new_item: Callable[[TodoItemData], None],
-    ) -> None:
+    ) -> [TodoItemData]:
         """Compare original and updated lists to find new TodoItems.
 
         For each new TodoItem found, call the provided on_new_item callback.
@@ -98,6 +92,7 @@ class GoogleKeepSyncCoordinator(DataUpdateCoordinator[list[GKeepList]]):
         :param updated_lists: The updated todo list data.
         # :param on_new_item: Callback function to execute for each new item found.
         """
+        new_items = []
         # for each list
         for updated_list_id, updated_list in updated_lists.items():
             if updated_list_id not in original_lists:
@@ -115,14 +110,36 @@ class GoogleKeepSyncCoordinator(DataUpdateCoordinator[list[GKeepList]]):
 
                 # if todo is not in original list, then it is new
                 if updated_list_item_id not in original_list.items:
-                    item_data = TodoItemData(
-                        item_name=updated_list_item.summary,
-                        item_id=updated_list_item_id,
-                        item_checked=updated_list_item.checked,
-                        list_name=(f"{list_prefix} " if list_prefix else "")
-                        + updated_list.name,
-                        list_id=updated_list_id,
+                    # Get HA List entity_id for _gkeep_list_id
+                    entity_reg = entity_registry.async_get(self.hass)
+                    uuid = f"{DOMAIN}.list.{updated_list_id}"
+                    list_entity_id = entity_reg.async_get_entity_id(
+                        Platform.TODO, DOMAIN, uuid
+                    )
+                    new_items.append(
+                        TodoItemData(
+                            item=updated_list_item.summary, entity_id=list_entity_id
+                        )
                     )
 
-                    _LOGGER.debug("Found new TodoItem: %s", item_data)
-                    on_new_item(item_data)
+                    _LOGGER.debug(
+                        "Found new TodoItem: '%s' in List entity_id: '%s'",
+                        updated_list_item.summary,
+                        list_entity_id,
+                    )
+        return new_items
+
+    async def _notify_new_items(self, new_items: [TodoItemData]) -> None:
+        """Emit add_item service call event for new remote Todo items."""
+        for new_item in new_items:
+            event_data = {
+                "domain": "todo",
+                "service": "add_item",
+                "service_data": {
+                    "item": new_item.item,
+                    "entity_id": [new_item.entity_id],
+                },
+            }
+            self.hass.bus.async_fire(
+                EVENT_CALL_SERVICE, event_data, origin=EventOrigin.remote
+            )

--- a/custom_components/google_keep_sync/coordinator.py
+++ b/custom_components/google_keep_sync/coordinator.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from datetime import timedelta
 
 from gkeepapi.node import List as GKeepList
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -27,6 +28,7 @@ class GoogleKeepSyncCoordinator(DataUpdateCoordinator[list[GKeepList]]):
         self,
         hass: HomeAssistant,
         api: GoogleKeepAPI,
+        entry: ConfigEntry,
     ) -> None:
         """Initialize the Google Keep Todo coordinator."""
         super().__init__(
@@ -36,6 +38,7 @@ class GoogleKeepSyncCoordinator(DataUpdateCoordinator[list[GKeepList]]):
             update_interval=timedelta(minutes=15),
         )
         self.api = api
+        self.config_entry = entry
 
     # Define the update method for the coordinator
     async def _async_update_data(self) -> list[GKeepList]:
@@ -94,28 +97,28 @@ class GoogleKeepSyncCoordinator(DataUpdateCoordinator[list[GKeepList]]):
         # :param on_new_item: Callback function to execute for each new item found.
         """
         # for each list
-        for updated_list_id, upldated_list in updated_lists.items():
+        for updated_list_id, updated_list in updated_lists.items():
             if updated_list_id not in original_lists:
-                _LOGGER.debug("Found new list not in original: %s", upldated_list.name)
+                _LOGGER.debug("Found new list not in original: %s", updated_list.name)
                 continue
 
             # for each todo item in the list
-            upldated_list_item: TodoItem
+            updated_list_item: TodoItem
             for (
-                upldated_list_item_id,
-                upldated_list_item,
-            ) in upldated_list.items.items():
+                updated_list_item_id,
+                updated_list_item,
+            ) in updated_list.items.items():
                 # get original list with updated_list_id
                 original_list = original_lists[updated_list_id]
 
                 # if todo is not in original list, then it is new
-                if upldated_list_item_id not in original_list.items:
+                if updated_list_item_id not in original_list.items:
                     item_data = TodoItemData(
-                        item_name=upldated_list_item.summary,
-                        item_id=upldated_list_item_id,
-                        item_checked=upldated_list_item.checked,
+                        item_name=updated_list_item.summary,
+                        item_id=updated_list_item_id,
+                        item_checked=updated_list_item.checked,
                         list_name=(f"{list_prefix} " if list_prefix else "")
-                        + upldated_list.name,
+                        + updated_list.name,
                         list_id=updated_list_id,
                     )
 

--- a/custom_components/google_keep_sync/coordinator.py
+++ b/custom_components/google_keep_sync/coordinator.py
@@ -1,6 +1,8 @@
 """DataUpdateCoordinator for the Google Keep Sync component."""
 
 import logging
+from collections import namedtuple
+from collections.abc import Callable
 from datetime import timedelta
 
 from gkeepapi.node import List as GKeepList
@@ -8,9 +10,14 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import GoogleKeepAPI
-from .const import DOMAIN
+from .const import DOMAIN, EVENT_NEW_ITEM
 
 _LOGGER = logging.getLogger(__name__)
+TodoItem = namedtuple("TodoItem", ["summary", "checked"])
+TodoList = namedtuple("TodoList", ["name", "items"])
+TodoItemData = namedtuple(
+    "TodoItemData", ["item_name", "item_id", "item_checked", "list_name", "list_id"]
+)
 
 
 class GoogleKeepSyncCoordinator(DataUpdateCoordinator[list[GKeepList]]):
@@ -41,60 +48,73 @@ class GoogleKeepSyncCoordinator(DataUpdateCoordinator[list[GKeepList]]):
             result = await self.api.async_sync_data(lists_to_sync)
             # save lists after syncing
             updated_lists = await self._parse_gkeep_data_dict()
-            # compare both list for changes
-            await self._check_gkeep_lists_changes(original_lists, updated_lists)
+            # compare both list for changes, and fire event for changes
+            await self._handle_new_items_added(
+                original_lists,
+                updated_lists,
+                self.config_entry.data.get("list_prefix", ""),
+                lambda item_data: self.hass.bus.async_fire(EVENT_NEW_ITEM, item_data),
+            )
 
             return result
         except Exception as error:
             raise UpdateFailed(f"Error communicating with API: {error}") from error
 
-    async def _parse_gkeep_data_dict(self) -> dict[str, dict[str, dict[str, str]]]:
-        """Parse unchecked gkeep api data to a dictionary."""
-        todo_lists = {}
+    async def _parse_gkeep_data_dict(self) -> dict[str, TodoList]:
+        """Parse unchecked gkeep data to a dictionary, with the list id as the key."""
+        all_keep_lists = {}
 
         # for each list
-        for glist in self.data or []:
+        for keep_list in self.data or []:
             # get all the unchecked items only
             items = {
-                item.id: {"summary": item.text, "checked": item.checked}
-                for item in glist.items
+                item.id: TodoItem(summary=item.text, checked=item.checked)
+                for item in keep_list.items
                 if not item.checked
             }
-            todo_lists[glist.id] = {"name": glist.title, "items": items}
-        return todo_lists
+            all_keep_lists[keep_list.id] = TodoList(name=keep_list.title, items=items)
+        return all_keep_lists
 
-    async def _check_gkeep_lists_changes(self, original_lists, updated_lists) -> None:
-        """Compare original_lists and updated_lists lists.
+    async def _handle_new_items_added(
+        self,
+        original_lists: dict[str, TodoList],
+        updated_lists: dict[str, TodoList],
+        list_prefix: str,
+        on_new_item: Callable[[TodoItemData], None],
+    ) -> None:
+        """Compare original and updated lists to find new TodoItems.
 
-        Report on any new TodoItem's that have been added to any
-        lists in updated_lists that are not in original_lists.
+        For each new TodoItem found, call the provided on_new_item callback.
+
+        :param original_lists: The original todo list data.
+        :param updated_lists: The updated todo list data.
+        # :param on_new_item: Callback function to execute for each new item found.
         """
         # for each list
         for updated_list_id, upldated_list in updated_lists.items():
             if updated_list_id not in original_lists:
-                _LOGGER.debug(
-                    "Found new list not in original: %s", upldated_list["name"]
-                )
+                _LOGGER.debug("Found new list not in original: %s", upldated_list.name)
                 continue
 
             # for each todo item in the list
-            for upldated_list_item_id, upldated_list_item in upldated_list[
-                "items"
-            ].items():
-                # if todo is not in original list, then it is new
-                if (
-                    upldated_list_item_id
-                    not in original_lists[updated_list_id]["items"]
-                ):
-                    list_prefix = self.config_entry.data.get("list_prefix", "")
-                    data = {
-                        "item_name": upldated_list_item["summary"],
-                        "item_id": upldated_list_item_id,
-                        "item_checked": upldated_list_item["checked"],
-                        "list_name": (f"{list_prefix} " if list_prefix else "")
-                        + upldated_list["name"],
-                        "list_id": updated_list_id,
-                    }
+            upldated_list_item: TodoItem
+            for (
+                upldated_list_item_id,
+                upldated_list_item,
+            ) in upldated_list.items.items():
+                # get original list with updated_list_id
+                original_list = original_lists[updated_list_id]
 
-                    _LOGGER.debug("Found new TodoItem: %s", data)
-                    self.hass.bus.async_fire("google_keep_sync_new_item", data)
+                # if todo is not in original list, then it is new
+                if upldated_list_item_id not in original_list.items:
+                    item_data = TodoItemData(
+                        item_name=upldated_list_item.summary,
+                        item_id=upldated_list_item_id,
+                        item_checked=upldated_list_item.checked,
+                        list_name=(f"{list_prefix} " if list_prefix else "")
+                        + upldated_list.name,
+                        list_id=updated_list_id,
+                    )
+
+                    _LOGGER.debug("Found new TodoItem: %s", item_data)
+                    on_new_item(item_data)

--- a/custom_components/google_keep_sync/coordinator.py
+++ b/custom_components/google_keep_sync/coordinator.py
@@ -59,7 +59,9 @@ class GoogleKeepSyncCoordinator(DataUpdateCoordinator[list[GKeepList]]):
                 original_lists,
                 updated_lists,
                 self.config_entry.data.get("list_prefix", ""),
-                lambda item_data: self.hass.bus.async_fire(EVENT_NEW_ITEM, item_data),
+                lambda item_data: self.hass.bus.async_fire(
+                    EVENT_NEW_ITEM, item_data._asdict()
+                ),
             )
 
             return result

--- a/custom_components/google_keep_sync/coordinator.py
+++ b/custom_components/google_keep_sync/coordinator.py
@@ -1,0 +1,100 @@
+"""DataUpdateCoordinator for the Google Keep Sync component."""
+
+import logging
+from datetime import timedelta
+
+from gkeepapi.node import List as GKeepList
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .api import GoogleKeepAPI
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class GoogleKeepSyncCoordinator(DataUpdateCoordinator[list[GKeepList]]):
+    """Coordinator for updating task data from Google Keep."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        api: GoogleKeepAPI,
+    ) -> None:
+        """Initialize the Google Keep Todo coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=timedelta(minutes=15),
+        )
+        self.api = api
+
+    # Define the update method for the coordinator
+    async def _async_update_data(self) -> list[GKeepList]:
+        """Fetch data from API."""
+        try:
+            # save lists prior to syncing
+            original_lists = await self._parse_gkeep_data_dict()
+            # Directly call the async_sync_data method
+            lists_to_sync = self.config_entry.data.get("lists_to_sync", [])
+            result = await self.api.async_sync_data(lists_to_sync)
+            # save lists after syncing
+            updated_lists = await self._parse_gkeep_data_dict()
+            # compare both list for changes
+            await self._check_gkeep_lists_changes(original_lists, updated_lists)
+
+            return result
+        except Exception as error:
+            raise UpdateFailed(f"Error communicating with API: {error}") from error
+
+    async def _parse_gkeep_data_dict(self) -> dict[str, dict[str, dict[str, str]]]:
+        """Parse unchecked gkeep api data to a dictionary."""
+        todo_lists = {}
+
+        # for each list
+        for glist in self.data or []:
+            # get all the unchecked items only
+            items = {
+                item.id: {"summary": item.text, "checked": item.checked}
+                for item in glist.items
+                if not item.checked
+            }
+            todo_lists[glist.id] = {"name": glist.title, "items": items}
+        return todo_lists
+
+    async def _check_gkeep_lists_changes(self, original_lists, updated_lists) -> None:
+        """Compare original_lists and updated_lists lists.
+
+        Report on any new TodoItem's that have been added to any
+        lists in updated_lists that are not in original_lists.
+        """
+        # for each list
+        for updated_list_id, upldated_list in updated_lists.items():
+            if updated_list_id not in original_lists:
+                _LOGGER.debug(
+                    "Found new list not in original: %s", upldated_list["name"]
+                )
+                continue
+
+            # for each todo item in the list
+            for upldated_list_item_id, upldated_list_item in upldated_list[
+                "items"
+            ].items():
+                # if todo is not in original list, then it is new
+                if (
+                    upldated_list_item_id
+                    not in original_lists[updated_list_id]["items"]
+                ):
+                    list_prefix = self.config_entry.data.get("list_prefix", "")
+                    data = {
+                        "item_name": upldated_list_item["summary"],
+                        "item_id": upldated_list_item_id,
+                        "item_checked": upldated_list_item["checked"],
+                        "list_name": (f"{list_prefix} " if list_prefix else "")
+                        + upldated_list["name"],
+                        "list_id": updated_list_id,
+                    }
+
+                    _LOGGER.debug("Found new TodoItem: %s", data)
+                    self.hass.bus.async_fire("google_keep_sync_new_item", data)

--- a/custom_components/google_keep_sync/todo.py
+++ b/custom_components/google_keep_sync/todo.py
@@ -53,11 +53,6 @@ class GoogleKeepTodoListEntity(
             f"{list_prefix} " if list_prefix else ""
         ) + f"{gkeep_list.title}"
         self._attr_unique_id = f"{DOMAIN}.list.{gkeep_list.id}"
-        self.entity_id = self._get_entity_id(gkeep_list.title)
-
-    def _get_entity_id(self, title: str) -> str:
-        """Return the entity ID for the given title."""
-        return f"todo.google_keep_{title.lower().replace(' ', '_')}"
 
     async def async_delete_todo_items(self, uids: list[str]) -> None:
         """Delete todo items from Google Keep."""

--- a/custom_components/google_keep_sync/todo.py
+++ b/custom_components/google_keep_sync/todo.py
@@ -51,6 +51,16 @@ class GoogleKeepTodoListEntity(
         ) + f"{gkeep_list.title}"
         self._attr_unique_id = f"{DOMAIN}.list.{gkeep_list.id}"
 
+        # Set the default entity ID based on the list title.
+        # We use a prefix to avoid conflicts with todo entities from other
+        # integrations, and so the entities specific to this integration
+        # can be filtered easily in developer tools.
+        self.entity_id = self._get_default_entity_id(gkeep_list.title)
+
+    def _get_default_entity_id(self, title: str) -> str:
+        """Return the entity ID for the given title."""
+        return f"todo.google_keep_{title.lower().replace(' ', '_')}"
+
     async def async_delete_todo_items(self, uids: list[str]) -> None:
         """Delete todo items from Google Keep."""
         list_id = self._gkeep_list_id

--- a/custom_components/google_keep_sync/todo.py
+++ b/custom_components/google_keep_sync/todo.py
@@ -1,7 +1,6 @@
 """Platform for creating to do list entries based on Google Keep lists."""
 
 import logging
-from datetime import timedelta
 
 import gkeepapi
 from homeassistant.components.todo import (
@@ -20,8 +19,6 @@ from homeassistant.helpers.update_coordinator import (
 
 from .const import DOMAIN
 from .coordinator import GoogleKeepSyncCoordinator
-
-SCAN_INTERVAL = timedelta(minutes=15)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,9 +1,10 @@
 """Unit tests for the todo component."""
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.components.todo import TodoItem
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.google_keep_sync.coordinator import (
     GoogleKeepSyncCoordinator,
@@ -29,6 +30,21 @@ def mock_api():
     api = MagicMock()
     api.async_create_todo_item = MagicMock()
     return api
+
+
+async def test_async_update_data(
+    mock_api: MagicMock, mock_hass: MagicMock, mock_config_entry: MockConfigEntry
+):
+    """Test update_data method."""
+    with patch.object(mock_api, "async_sync_data", AsyncMock()):
+        mock_api.async_sync_data.return_value = ["list1", "list2"]
+
+        coordinator = GoogleKeepSyncCoordinator(mock_hass, mock_api)
+        coordinator.config_entry = mock_config_entry
+
+        result = await coordinator._async_update_data()
+
+        assert result == ["list1", "list2"]
 
 
 async def test_parse_gkeep_data_dict_empty(mock_api: MagicMock, mock_hass: MagicMock):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3,12 +3,11 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from homeassistant.components.todo import TodoItem
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.google_keep_sync.coordinator import (
     GoogleKeepSyncCoordinator,
-    TodoItem,  # noqa: F811
+    TodoItem,
     TodoItemData,
     TodoList,
 )
@@ -39,7 +38,7 @@ async def test_async_update_data(
     with patch.object(mock_api, "async_sync_data", AsyncMock()):
         mock_api.async_sync_data.return_value = ["list1", "list2"]
 
-        coordinator = GoogleKeepSyncCoordinator(mock_hass, mock_api)
+        coordinator = GoogleKeepSyncCoordinator(mock_hass, mock_api, mock_config_entry)
         coordinator.config_entry = mock_config_entry
 
         result = await coordinator._async_update_data()
@@ -47,18 +46,22 @@ async def test_async_update_data(
         assert result == ["list1", "list2"]
 
 
-async def test_parse_gkeep_data_dict_empty(mock_api: MagicMock, mock_hass: MagicMock):
+async def test_parse_gkeep_data_dict_empty(
+    mock_api: MagicMock, mock_hass: MagicMock, mock_config_entry: MockConfigEntry
+):
     """Test _parse_gkeep_data_dict when empty."""
     test_input: dict = {}
     expected: dict = {}
-    coordinator = GoogleKeepSyncCoordinator(mock_hass, mock_api)
+    coordinator = GoogleKeepSyncCoordinator(mock_hass, mock_api, mock_config_entry)
     coordinator.data = test_input
 
     actual = await coordinator._parse_gkeep_data_dict()
     assert actual == expected
 
 
-async def test_parse_gkeep_data_dict_normal(mock_api: MagicMock, mock_hass: MagicMock):
+async def test_parse_gkeep_data_dict_normal(
+    mock_api: MagicMock, mock_hass: MagicMock, mock_config_entry: MockConfigEntry
+):
     """Test _parse_gkeep_data_dict with data."""
     mock_list = MagicMock(id="grocery_list_id", title="Grocery List")
     mock_item = MagicMock(id="milk_item_id", text="Milk", checked=False)
@@ -70,17 +73,19 @@ async def test_parse_gkeep_data_dict_normal(mock_api: MagicMock, mock_hass: Magi
         )
     }
 
-    coordinator = GoogleKeepSyncCoordinator(mock_hass, mock_api)
+    coordinator = GoogleKeepSyncCoordinator(mock_hass, mock_api, mock_config_entry)
     coordinator.data = [mock_list]
 
     actual = await coordinator._parse_gkeep_data_dict()
     assert actual == expected
 
 
-async def test_handle_new_items_added(mock_api: MagicMock, mock_hass: MagicMock):
+async def test_handle_new_items_added(
+    mock_api: MagicMock, mock_hass: MagicMock, mock_config_entry: MockConfigEntry
+):
     """Test handling new items added to a list."""
     # Set up coordinator and mock API
-    coordinator = GoogleKeepSyncCoordinator(mock_hass, mock_api)
+    coordinator = GoogleKeepSyncCoordinator(mock_hass, mock_api, mock_config_entry)
 
     list1 = {
         "grocery_list_id": TodoList(
@@ -114,10 +119,12 @@ async def test_handle_new_items_added(mock_api: MagicMock, mock_hass: MagicMock)
     callback.assert_called_once()
 
 
-async def test_handle_new_items_not_added(mock_api: MagicMock, mock_hass: MagicMock):
+async def test_handle_new_items_not_added(
+    mock_api: MagicMock, mock_hass: MagicMock, mock_config_entry: MockConfigEntry
+):
     """Test handling when no new items are added to a list."""
     # Set up coordinator and mock API
-    coordinator = GoogleKeepSyncCoordinator(mock_hass, mock_api)
+    coordinator = GoogleKeepSyncCoordinator(mock_hass, mock_api, mock_config_entry)
 
     list1 = {
         "grocery_list_id": TodoList(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,118 @@
+"""Unit tests for the todo component."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.components.todo import TodoItem
+
+from custom_components.google_keep_sync.coordinator import (
+    GoogleKeepSyncCoordinator,
+    TodoItem,  # noqa: F811
+    TodoItemData,
+    TodoList,
+)
+
+
+@pytest.fixture
+def mock_hass():
+    """Fixture for mocking Home Assistant."""
+    mock_hass = MagicMock()
+    mock_hass.async_add_executor_job.side_effect = lambda f, *args, **kwargs: f(
+        *args, **kwargs
+    )
+    return mock_hass
+
+
+@pytest.fixture
+def mock_api():
+    """Return a mocked GoogleKeepAPI."""
+    api = MagicMock()
+    api.async_create_todo_item = MagicMock()
+    return api
+
+
+async def test_parse_gkeep_data_dict_empty(mock_api: MagicMock, mock_hass: MagicMock):
+    """Test _parse_gkeep_data_dict when empty."""
+    test_input: dict = {}
+    expected: dict = {}
+    coordinator = GoogleKeepSyncCoordinator(mock_hass, mock_api)
+    coordinator.data = test_input
+
+    actual = await coordinator._parse_gkeep_data_dict()
+    assert actual == expected
+
+
+async def test_parse_gkeep_data_dict_normal(mock_api: MagicMock, mock_hass: MagicMock):
+    """Test _parse_gkeep_data_dict with data."""
+    mock_list = MagicMock(id="grocery_list_id", title="Grocery List")
+    mock_item = MagicMock(id="milk_item_id", text="Milk", checked=False)
+    mock_list.items = [mock_item]
+    expected = {
+        "grocery_list_id": TodoList(
+            name="Grocery List",
+            items={"milk_item_id": TodoItem(summary="Milk", checked=False)},
+        )
+    }
+
+    coordinator = GoogleKeepSyncCoordinator(mock_hass, mock_api)
+    coordinator.data = [mock_list]
+
+    actual = await coordinator._parse_gkeep_data_dict()
+    assert actual == expected
+
+
+async def test_handle_new_items_added(mock_api: MagicMock, mock_hass: MagicMock):
+    """Test handling new items added to a list."""
+    # Set up coordinator and mock API
+    coordinator = GoogleKeepSyncCoordinator(mock_hass, mock_api)
+
+    list1 = {
+        "grocery_list_id": TodoList(
+            name="Grocery List",
+            items={"milk_item_id": TodoItem(summary="Milk", checked=False)},
+        )
+    }
+    list2 = {
+        "grocery_list_id": TodoList(
+            name="Grocery List",
+            items={
+                "milk_item_id": TodoItem(summary="Milk", checked=False),
+                "bread_item_id": TodoItem(summary="Bread", checked=False),
+            },
+        )
+    }
+
+    # Call method under test
+    callback = MagicMock()
+    await coordinator._handle_new_items_added(list1, list2, "", callback)
+
+    # Assertions
+    expected = TodoItemData(
+        item_name="Bread",
+        item_id="bread_item_id",
+        item_checked=False,
+        list_name="Grocery List",
+        list_id="grocery_list_id",
+    )
+    callback.assert_called_with(expected)
+    callback.assert_called_once()
+
+
+async def test_handle_new_items_not_added(mock_api: MagicMock, mock_hass: MagicMock):
+    """Test handling when no new items are added to a list."""
+    # Set up coordinator and mock API
+    coordinator = GoogleKeepSyncCoordinator(mock_hass, mock_api)
+
+    list1 = {
+        "grocery_list_id": TodoList(
+            name="Grocery List",
+            items={"milk_item_id": TodoItem(summary="Milk", checked=False)},
+        )
+    }
+
+    # Call method under test
+    callback = MagicMock()
+    await coordinator._handle_new_items_added(list1, list1, "", callback)
+
+    # Assertions
+    callback.assert_not_called()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -83,7 +83,7 @@ async def test_parse_gkeep_data_dict_normal(
     assert actual == expected
 
 
-async def test_handle_new_items_added(
+async def test_get_new_items_added(
     mock_api: MagicMock,
     mock_hass: MagicMock,
     mock_config_entry: MockConfigEntry,
@@ -114,7 +114,7 @@ async def test_handle_new_items_added(
 
         # Call method under test
         # callback = MagicMock()
-        new_items = await coordinator._handle_new_items_added(list1, list2)
+        new_items = await coordinator._get_new_items_added(list1, list2)
 
         # Assertions
         expected = [
@@ -126,7 +126,7 @@ async def test_handle_new_items_added(
         assert new_items == expected
 
 
-async def test_handle_new_items_not_added(
+async def test_get_new_items_not_added(
     mock_api: MagicMock, mock_hass: MagicMock, mock_config_entry: MockConfigEntry
 ):
     """Test handling when no new items are added to a list."""
@@ -141,7 +141,7 @@ async def test_handle_new_items_not_added(
     }
 
     # Call method under test
-    new_items = await coordinator._handle_new_items_added(list1, list1)
+    new_items = await coordinator._get_new_items_added(list1, list1)
 
     # Assertions
     assert new_items == []

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -17,7 +17,7 @@ from custom_components.google_keep_sync.todo import (
 def mock_api():
     """Return a mocked Google Keep API."""
     with patch(
-        "custom_components.google_keep_sync.todo.GoogleKeepAPI"
+        "custom_components.google_keep_sync.api.GoogleKeepAPI"
     ) as mock_api_class:
         mock_api = mock_api_class.return_value
         mock_api.async_create_todo_item = AsyncMock(return_value="new_item_id")
@@ -48,9 +48,7 @@ async def test_async_setup_entry(
 ):
     """Test platform setup of todo."""
     mock_config_entry.add_to_hass(hass)
-    hass.data[DOMAIN] = {
-        mock_config_entry.entry_id: {"api": mock_api, "coordinator": mock_coordinator}
-    }
+    hass.data[DOMAIN] = {mock_config_entry.entry_id: mock_coordinator}
 
     with patch(
         "homeassistant.helpers.entity_platform.AddEntitiesCallback"
@@ -68,6 +66,7 @@ async def test_create_todo_item(hass: HomeAssistant, mock_api, mock_coordinator)
     list_prefix = ""
 
     # Initialize the coordinator data
+    mock_coordinator.api = mock_api
     mock_coordinator.data = [
         {"id": "grocery_list", "title": "Grocery List", "items": []}
     ]
@@ -91,9 +90,7 @@ async def test_create_todo_item(hass: HomeAssistant, mock_api, mock_coordinator)
     mock_coordinator.async_refresh = AsyncMock(side_effect=async_refresh_side_effect)
 
     # Create the entity and add a new item
-    entity = GoogleKeepTodoListEntity(
-        mock_api, mock_coordinator, grocery_list, list_prefix
-    )
+    entity = GoogleKeepTodoListEntity(mock_coordinator, grocery_list, list_prefix)
     await entity.async_create_todo_item(TodoItem(summary="Milk"))
 
     # Ensure the proper methods were called
@@ -114,6 +111,7 @@ async def test_update_todo_item(hass: HomeAssistant, mock_api, mock_coordinator)
     initial_item = {"id": "milk_item", "text": "Milk", "checked": False}
     grocery_list.items = [initial_item]
 
+    mock_coordinator.api = mock_api
     mock_coordinator.data = [
         {"id": "grocery_list", "title": "Grocery List", "items": [initial_item]}
     ]
@@ -135,9 +133,7 @@ async def test_update_todo_item(hass: HomeAssistant, mock_api, mock_coordinator)
     mock_coordinator.async_refresh = AsyncMock(side_effect=async_refresh_side_effect)
 
     # Create the entity
-    entity = GoogleKeepTodoListEntity(
-        mock_api, mock_coordinator, grocery_list, list_prefix
-    )
+    entity = GoogleKeepTodoListEntity(mock_coordinator, grocery_list, list_prefix)
     entity.hass = hass
 
     # update item
@@ -167,6 +163,7 @@ async def test_delete_todo_items(hass: HomeAssistant, mock_api, mock_coordinator
         {"id": "eggs_item", "text": "Eggs", "checked": False},
     ]
     grocery_list.items = initial_items
+    mock_coordinator.api = mock_api
     mock_coordinator.data = [
         {"id": "grocery_list", "title": "Grocery List", "items": initial_items}
     ]
@@ -186,9 +183,7 @@ async def test_delete_todo_items(hass: HomeAssistant, mock_api, mock_coordinator
     mock_coordinator.async_refresh = AsyncMock(side_effect=async_refresh_side_effect)
 
     # Create the entity
-    entity = GoogleKeepTodoListEntity(
-        mock_api, mock_coordinator, grocery_list, list_prefix
-    )
+    entity = GoogleKeepTodoListEntity(mock_coordinator, grocery_list, list_prefix)
     entity.hass = hass
 
     # Delete item
@@ -209,9 +204,7 @@ async def test_default_list_prefix(hass, mock_api, mock_coordinator):
     list_prefix = ""
     grocery_list = MagicMock(id="grocery_list", title="Grocery List")
 
-    entity = GoogleKeepTodoListEntity(
-        mock_api, mock_coordinator, grocery_list, list_prefix
-    )
+    entity = GoogleKeepTodoListEntity(mock_coordinator, grocery_list, list_prefix)
 
     # Test default prefix
     assert entity.name == "Grocery List"
@@ -224,7 +217,5 @@ async def test_custom_list_prefix(hass, mock_api, mock_coordinator):
     grocery_list = MagicMock(id="grocery_list", title="Grocery List")
 
     # Test custom prefix
-    entity = GoogleKeepTodoListEntity(
-        mock_api, mock_coordinator, grocery_list, list_prefix
-    )
+    entity = GoogleKeepTodoListEntity(mock_coordinator, grocery_list, list_prefix)
     assert entity.name == "Foo Grocery List"


### PR DESCRIPTION
Now that the API has a single point of syncing, we can get onto the fun stuff 😃 
I have been using this code for a couple weeks now and it is working pretty nicely.

Google recently removed third party integrations from Google Assistant. Now you can re-create these integrations.

When a new item is added to a synced list via Google Assistant or from Google Keep, a `google_keep_sync_new_item` event will be triggered. This allows Home Assistant to pick up new items from Google Keep and sync them with third party systems such as Trello, Bring, Anylist etc.

Note: Only new items that are not completed at the time of syncing will trigger the event.