### PR TITLE
Feature automatic sort option

### DIFF
--- a/custom_components/google_keep_sync/__init__.py
+++ b/custom_components/google_keep_sync/__init__.py
@@ -34,7 +34,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         try:
             # Directly call the async_sync_data method
             lists_to_sync = entry.data.get("lists_to_sync", [])
-            return await api.async_sync_data(lists_to_sync)
+
+            # Check if we need to sort the lists
+            auto_sort = entry.data.get("list_auto_sort", False)
+
+            return await api.async_sync_data(lists_to_sync, auto_sort)
         except Exception as error:
             raise UpdateFailed(f"Error communicating with API: {error}") from error
 

--- a/custom_components/google_keep_sync/api.py
+++ b/custom_components/google_keep_sync/api.py
@@ -215,7 +215,7 @@ class GoogleKeepAPI:
 
     @authenticated_required
     async def async_sync_data(
-        self, lists_to_sync: list[str]
+        self, lists_to_sync: list[str], sort_lists=False
     ) -> list[gkeepapi.node.List] | None:
         """Synchronize data only from configured lists with Google Keep."""
         try:
@@ -225,9 +225,14 @@ class GoogleKeepAPI:
             # only get the lists that are configured to sync
             lists = []
             for list_id in lists_to_sync:
-                lists.append(
-                    await self._hass.async_add_executor_job(self._keep.get, list_id)
+                keep_list = await self._hass.async_add_executor_job(
+                    self._keep.get, list_id
                 )
+
+                if sort_lists:
+                    await self._hass.async_add_executor_job(keep_list.sort_items)
+
+                lists.append(keep_list)
 
             return lists
 

--- a/custom_components/google_keep_sync/strings.json
+++ b/custom_components/google_keep_sync/strings.json
@@ -30,7 +30,7 @@
         },
         "data_description": {
           "list_prefix": "(Optional, can be blank) Add a unique identifier to the front of each list name in Home Assistant. For example, entering 'Google' will display your shopping list as 'Google Shopping List'. Leave empty to have the lists named as they are in Google Keep.",
-          "list_auto_sort": "If checked, all of your lists will be changed to be sorted alphabetically. This is bidirectional, so your lists in both Home Assistant and Google Keep will be sorted."
+          "list_auto_sort": "If checked, all of your selected lists will be changed to be sorted alphabetically. This is bidirectional, so your lists in both Home Assistant and Google Keep will be sorted."
         }
       },
       "reauth_confirm": {
@@ -51,7 +51,7 @@
         },
         "data_description": {
           "list_prefix": "(Optional, can be blank) Add a unique identifier to the front of each list name in Home Assistant. For example, entering 'Google' will display your shopping list as 'Google Shopping List'. Leave empty to have the lists named as they are in Google Keep.",
-          "list_auto_sort": "If checked, all of your lists will be changed to be sorted alphabetically. This is bidirectional, so your lists in both Home Assistant and Google Keep will be sorted."
+          "list_auto_sort": "If checked, all of your selected lists will be changed to be sorted alphabetically. This is bidirectional, so your lists in both Home Assistant and Google Keep will be sorted."
         }
       }
     },

--- a/custom_components/google_keep_sync/strings.json
+++ b/custom_components/google_keep_sync/strings.json
@@ -25,10 +25,12 @@
         "description": "Choose which lists to synchronize and optionally add a prefix to the list names in Home Assistant.",
         "data": {
           "lists_to_sync": "Lists to Sync",
-          "list_prefix": "List Prefix"
+          "list_prefix": "List Prefix",
+          "list_auto_sort": "Automatically Sort Lists"
         },
         "data_description": {
-          "list_prefix": "(Optional, can be blank) Add a unique identifier to the front of each list name in Home Assistant. For example, entering 'Google' will display your shopping list as 'Google Shopping List'. Leave empty to have the lists named as they are in Google Keep."
+          "list_prefix": "(Optional, can be blank) Add a unique identifier to the front of each list name in Home Assistant. For example, entering 'Google' will display your shopping list as 'Google Shopping List'. Leave empty to have the lists named as they are in Google Keep.",
+          "list_auto_sort": "If checked, all of your lists will be changed to be sorted alphabetically. This is bidirectional, so your lists in both Home Assistant and Google Keep will be sorted."
         }
       },
       "reauth_confirm": {
@@ -44,10 +46,12 @@
         "description": "Choose which lists to synchronize and optionally add a prefix to the list names in Home Assistant.",
         "data": {
           "lists_to_sync": "Lists to Sync",
-          "list_prefix": "List Prefix"
+          "list_prefix": "List Prefix",
+          "list_auto_sort": "Automatically Sort Lists"
         },
         "data_description": {
-          "list_prefix": "(Optional, can be blank) Add a unique identifier to the front of each list name in Home Assistant. For example, entering 'Google' will display your shopping list as 'Google Shopping List'. Leave empty to have the lists named as they are in Google Keep."
+          "list_prefix": "(Optional, can be blank) Add a unique identifier to the front of each list name in Home Assistant. For example, entering 'Google' will display your shopping list as 'Google Shopping List'. Leave empty to have the lists named as they are in Google Keep.",
+          "list_auto_sort": "If checked, all of your lists will be changed to be sorted alphabetically. This is bidirectional, so your lists in both Home Assistant and Google Keep will be sorted."
         }
       }
     },

--- a/custom_components/google_keep_sync/translations/en.json
+++ b/custom_components/google_keep_sync/translations/en.json
@@ -25,10 +25,12 @@
                 "description": "Choose which lists to synchronize and optionally add a prefix to the list names in Home Assistant.",
                 "data": {
                     "lists_to_sync": "Lists to Sync",
-                    "list_prefix": "List Prefix"
+                    "list_prefix": "List Prefix",
+                    "list_auto_sort": "Automatically Sort Lists"
                 },
                 "data_description": {
-                    "list_prefix": "(Optional, can be blank) Add a unique identifier to the front of each list name in Home Assistant. For example, entering 'Google' will display your shopping list as 'Google Shopping List'. Leave empty to have the lists named as they are in Google Keep."
+                    "list_prefix": "(Optional, can be blank) Add a unique identifier to the front of each list name in Home Assistant. For example, entering 'Google' will display your shopping list as 'Google Shopping List'. Leave empty to have the lists named as they are in Google Keep.",
+                    "list_auto_sort": "If checked, all of your lists will be changed to be sorted alphabetically. This is bidirectional, so your lists in both Home Assistant and Google Keep will be sorted."
                 }
             },
             "reauth_confirm": {
@@ -44,10 +46,12 @@
                 "description": "Choose which lists to synchronize and optionally add a prefix to the list names in Home Assistant.",
                 "data": {
                     "lists_to_sync": "Lists to Sync",
-                    "list_prefix": "List Prefix"
+                    "list_prefix": "List Prefix",
+                    "list_auto_sort": "Automatically Sort Lists"
                 },
                 "data_description": {
-                    "list_prefix": "(Optional, can be blank) Add a unique identifier to the front of each list name in Home Assistant. For example, entering 'Google' will display your shopping list as 'Google Shopping List'. Leave empty to have the lists named as they are in Google Keep."
+                    "list_prefix": "(Optional, can be blank) Add a unique identifier to the front of each list name in Home Assistant. For example, entering 'Google' will display your shopping list as 'Google Shopping List'. Leave empty to have the lists named as they are in Google Keep.",
+                    "list_auto_sort": "If checked, all of your lists will be changed to be sorted alphabetically. This is bidirectional, so your lists in both Home Assistant and Google Keep will be sorted."
                 }
             }
         },

--- a/custom_components/google_keep_sync/translations/en.json
+++ b/custom_components/google_keep_sync/translations/en.json
@@ -30,7 +30,7 @@
                 },
                 "data_description": {
                     "list_prefix": "(Optional, can be blank) Add a unique identifier to the front of each list name in Home Assistant. For example, entering 'Google' will display your shopping list as 'Google Shopping List'. Leave empty to have the lists named as they are in Google Keep.",
-                    "list_auto_sort": "If checked, all of your lists will be changed to be sorted alphabetically. This is bidirectional, so your lists in both Home Assistant and Google Keep will be sorted."
+                    "list_auto_sort": "If checked, all of your selected lists will be changed to be sorted alphabetically. This is bidirectional, so your lists in both Home Assistant and Google Keep will be sorted."
                 }
             },
             "reauth_confirm": {
@@ -51,7 +51,7 @@
                 },
                 "data_description": {
                     "list_prefix": "(Optional, can be blank) Add a unique identifier to the front of each list name in Home Assistant. For example, entering 'Google' will display your shopping list as 'Google Shopping List'. Leave empty to have the lists named as they are in Google Keep.",
-                    "list_auto_sort": "If checked, all of your lists will be changed to be sorted alphabetically. This is bidirectional, so your lists in both Home Assistant and Google Keep will be sorted."
+                    "list_auto_sort": "If checked, all of your selected lists will be changed to be sorted alphabetically. This is bidirectional, so your lists in both Home Assistant and Google Keep will be sorted."
                 }
             }
         },

--- a/custom_components/google_keep_sync/translations/es.json
+++ b/custom_components/google_keep_sync/translations/es.json
@@ -25,10 +25,12 @@
                 "description": "Selecciona las listas de Google Keep que deseas sincronizar.\n\n*Prefijo de Lista* (Opcional): Agrega un identificador único al principio de cada nombre de lista en Home Assistant. Por ejemplo, al introducir 'Google', tu lista de compras se mostrará como 'Google Lista de Compras'. Déjalo vacío para mantener los nombres de las listas tal como están en Google Keep.",
                 "data": {
                     "lists_to_sync": "Listas a Sincronizar",
-                    "list_prefix": "Prefijo de Lista"
+                    "list_prefix": "Prefijo de Lista",
+                    "list_auto_sort": "Ordenar Listas Automáticamente"
                 },
                 "data_description": {
-                    "list_prefix": "(Opcional, puede dejarse en blanco) Agrega un identificador único al principio de cada nombre de lista en Home Assistant. Por ejemplo, al introducir 'Google', tu lista de compras se mostrará como 'Google Lista de Compras'. Déjalo vacío para mantener los nombres de las listas tal como están en Google Keep."
+                    "list_prefix": "(Opcional, puede dejarse en blanco) Agrega un identificador único al principio de cada nombre de lista en Home Assistant. Por ejemplo, al introducir 'Google', tu lista de compras se mostrará como 'Google Lista de Compras'. Déjalo vacío para mantener los nombres de las listas tal como están en Google Keep.",
+                    "list_auto_sort": "Si se marca, todas tus listas seleccionadas se cambiarán para ser ordenadas alfabéticamente. Esto es bidireccional, por lo que tus listas en Home Assistant y Google Keep serán ordenadas."
                 }
             },
             "reauth_confirm": {
@@ -44,10 +46,12 @@
                 "description": "Selecciona las listas de Google Keep que deseas sincronizar y, opcionalmente, añade un prefijo a los nombres de las listas en Home Assistant.",
                 "data": {
                     "lists_to_sync": "Listas a Sincronizar",
-                    "list_prefix": "Prefijo de Lista"
+                    "list_prefix": "Prefijo de Lista",
+                    "list_auto_sort": "Ordenar Listas Automáticamente"
                 },
                 "data_description": {
-                    "list_prefix": "(Opcional, puede dejarse en blanco) Agrega un identificador único al principio de cada nombre de lista en Home Assistant. Por ejemplo, al introducir 'Google', tu lista de compras se mostrará como 'Google Lista de Compras'. Déjalo vacío para mantener los nombres de las listas tal como están en Google Keep."
+                    "list_prefix": "(Opcional, puede dejarse en blanco) Agrega un identificador único al principio de cada nombre de lista en Home Assistant. Por ejemplo, al introducir 'Google', tu lista de compras se mostrará como 'Google Lista de Compras'. Déjalo vacío para mantener los nombres de las listas tal como están en Google Keep.",
+                    "list_auto_sort": "Si se marca, todas tus listas seleccionadas se cambiarán para ser ordenadas alfabéticamente. Esto es bidireccional, por lo que tus listas en Home Assistant y Google Keep serán ordenadas."
                 }
             }
         },

--- a/custom_components/google_keep_sync/translations/sv.json
+++ b/custom_components/google_keep_sync/translations/sv.json
@@ -25,10 +25,12 @@
                 "description": "Välj vilka Google Keep-listor som ska synkroniseras.\n\n*Listprefix* (Valfritt): Lägg till en unik identifierare framför varje listnamn i Home Assistant. Till exempel, genom att skriva 'Google' kommer din inköpslista att visas som 'Google Inköpslista'. Lämna fältet tomt för att behålla listornas namn som de är i Google Keep.",
                 "data": {
                     "lists_to_sync": "Listor att Synkronisera",
-                    "list_prefix": "Listprefix"
+                    "list_prefix": "Listprefix",
+                    "list_auto_sort": "Sortera Listor Automatiskt"
                 },
                 "data_description": {
-                    "list_prefix": "(Valfritt, kan lämnas tomt) Lägg till en unik identifierare framför varje listnamn i Home Assistant. Till exempel, genom att skriva 'Google' kommer din inköpslista att visas som 'Google Inköpslista'. Lämna fältet tomt för att behålla listornas namn som de är i Google Keep."
+                    "list_prefix": "(Valfritt, kan lämnas tomt) Lägg till en unik identifierare framför varje listnamn i Home Assistant. Till exempel, genom att skriva 'Google' kommer din inköpslista att visas som 'Google Inköpslista'. Lämna fältet tomt för att behålla listornas namn som de är i Google Keep.",
+                    "list_auto_sort": "Om markerad kommer alla dina valda listor att ändras för att sorteras alfabetiskt. Detta är tvåvägs, så dina listor i både Home Assistant och Google Keep kommer att sorteras."
                 }
             },
             "reauth_confirm": {
@@ -44,10 +46,12 @@
                 "description": "Välj vilka listor som ska synkroniseras och lägg eventuellt till ett prefix till listnamnen i Home Assistant.",
                 "data": {
                     "lists_to_sync": "Listor att Synkronisera",
-                    "list_prefix": "Listprefix"
+                    "list_prefix": "Listprefix",
+                    "list_auto_sort": "Sortera Listor Automatiskt"
                 },
                 "data_description": {
-                    "list_prefix": "(Valfritt, kan lämnas tomt) Lägg till en unik identifierare framför varje listnamn i Home Assistant. Till exempel, genom att skriva 'Google' kommer din inköpslista att visas som 'Google Inköpslista'. Lämna fältet tomt för att behålla listornas namn som de är i Google Keep."
+                    "list_prefix": "(Valfritt, kan lämnas tomt) Lägg till en unik identifierare framför varje listnamn i Home Assistant. Till exempel, genom att skriva 'Google' kommer din inköpslista att visas som 'Google Inköpslista'. Lämna fältet tomt för att behålla listornas namn som de är i Google Keep.",
+                    "list_auto_sort": "Om markerad kommer alla dina valda listor att ändras för att sorteras alfabetiskt. Detta är tvåvägs, så dina listor i både Home Assistant och Google Keep kommer att sorteras."
                 }
             }
         },

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -69,6 +69,7 @@ async def test_user_form_setup(hass: HomeAssistant, mock_google_keep_api):
     options_input = {
         "lists_to_sync": ["list_id_1", "list_id_2"],
         "list_prefix": "testprefix",
+        "list_auto_sort": False,
     }
     final_form_result = await hass.config_entries.flow.async_configure(
         credentials_form_result["flow_id"], user_input=options_input
@@ -83,6 +84,7 @@ async def test_user_form_setup(hass: HomeAssistant, mock_google_keep_api):
         "token": user_token,
         "lists_to_sync": ["list_id_1", "list_id_2"],
         "list_prefix": "testprefix",
+        "list_auto_sort": False,
     }
 
 
@@ -423,7 +425,11 @@ async def test_options_flow_create_entry(
         mock_config_entry.entry_id
     )
 
-    user_input = {"lists_to_sync": ["list_id_1", "list_id_2"], "list_prefix": "Test"}
+    user_input = {
+        "lists_to_sync": ["list_id_1", "list_id_2"],
+        "list_prefix": "Test",
+        "list_auto_sort": False,
+    }
 
     # Submit user input
     result = await hass.config_entries.options.async_configure(


### PR DESCRIPTION
Adds an automatic list sort option.

If selected when configuring the options, all selected lists will be sorted alphabetically. This is bidirectional, so it applies immediately after a sync in Home Assistant. It will be reflected in Google Keep after the next sync interval (to avoid extra unnecessary sync calls).