### PR TITLE
fix(tests): pin pycares>=4.8.0 for Python 3.13 compat

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,9 +1,9 @@
-aiodns>=3.2.0
+aiodns>=3.4.0
 aioresponses==0.7.8
 gkeepapi==0.16.0
 gpsoauth==1.1.1
 pre-commit==3.8.0
-pycares>=4.4.0
+pycares>=4.8.0
 pytest-homeassistant-custom-component
 pytest-socket==0.7.0
 tzdata


### PR DESCRIPTION
## Summary

CI has been red on main since 2026-04-07 due to a Python 3.13 + pycares compatibility issue:

```
AttributeError: module 'pycares' has no attribute 'ares_query_a_result'
```

Home Assistant's `aiodns` uses type annotations referencing `pycares.ares_query_a_result`. That symbol was added in pycares 4.6.0 but only exposed as a module attribute starting in 4.8.0. Under Python 3.13 annotations resolve at import time, so the missing symbol crashes test collection.

Bumping the pin from `pycares>=4.4.0` to `pycares>=4.8.0` fixes it.

## Test plan

- [x] Local pytest on Python 3.12 with pycares 4.8.0: 140 tests pass in 13.5s, 95% coverage
- [ ] CI on this branch (Python 3.13) — should now pass